### PR TITLE
add max_num_runs option

### DIFF
--- a/sweep.py
+++ b/sweep.py
@@ -59,6 +59,13 @@ def get_args():
         help="Whether to push the models to the hub during training.",
     )
 
+    parser.add_argument(
+        "--max_num_runs",
+        type=int,
+        default=None,
+        help="Maximum number of runs for the agent to start.",
+    )
+
     # parser.add_argument('--dataset', type=str, default='LDJnr/Puffin',
     #                     help='Dataset to use for training. Currently only supports Puffin.')
 
@@ -163,7 +170,7 @@ def sweep():
 
     if args.sweep_id is not None:
         # Run the sweep
-        wandb.agent(sweep_id, run_sweep, project=args.project, entity=args.entity)
+        wandb.agent(sweep_id, run_sweep, project=args.project, entity=args.entity, count=args.max_num_runs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds an option to limit the maximum number of runs to be started by the agent.
For example, with `--max_num_runs=3`, the agent will do 3 runs and exit.
This option is useful for people wanting to contribute a specific number of runs. Without this option, the agent will keep starting runs until the entire sweep is finished, and to stop an agent, one has to cancel a run which will be reported as failed to wandb.
Also very useful when working with job queues such as SLURM, where I would like to submit a bunch of low prior jobs, each doing, for example, 10 runs whenever there is capacity available.